### PR TITLE
Fix nick use (remove 'globals' via viper)

### DIFF
--- a/bot/help.go
+++ b/bot/help.go
@@ -23,7 +23,7 @@ func (h *HelpFmt) Use(i *Irc, command *Command) {
 
 func HelpHelp(i *Irc, command *Command) {
 	jww.DEBUG.Println("In HelpHelp")
-	help := "!quartermaster <cmd> {subcmd} <*args> (Commands:"
+	help := "!" + i.Conf.Me.Nick + " <cmd> {subcmd} <*args> (Commands:"
 	for k := range i.commands.Handlers.set {
 		if k == "quit" {
 			continue
@@ -49,7 +49,7 @@ func Help(i *Irc, command *Command) {
 		cmd = append([]string{}, command.Args[:1]...)
 	}
 
-	cm := NewCommand(command.Target, command.Sender, strings.Join(cmd, " "))
+	cm := NewCommand(command.Target, command.Sender, strings.Join(cmd, " "), i.Conf.Me.Nick)
 	i.help.Handlers.Dispatch(i, cm)
 
 }

--- a/bot/irc.go
+++ b/bot/irc.go
@@ -94,7 +94,7 @@ func (i *Irc) Connect() {
 			}
 		}
 
-		c := NewCommand(line.Target(), line.Nick, line.Text())
+		c := NewCommand(line.Target(), line.Nick, line.Text(), i.Conf.Me.Nick)
 		i.commands.Handlers.Dispatch(i, c)
 	})
 

--- a/bot/parser.go
+++ b/bot/parser.go
@@ -2,8 +2,6 @@ package bot
 
 import (
 	"strings"
-
-	"github.com/spf13/viper"
 )
 
 type Command struct {
@@ -11,19 +9,19 @@ type Command struct {
 	Cmd    string
 	Target string
 	Sender string
+	Nick   string
 	Args   []string
 }
 
 func (c *Command) GetSubCommand() *Command {
 	var cmd []string
 	if c.Target[0] == '#' {
-		nick := viper.GetString("nick")
-		cmd = append([]string{"!" + nick}, c.Args...)
+		cmd = append([]string{"!" + c.Nick}, c.Args...)
 	} else {
 		cmd = c.Args
 	}
 
-	cm := NewCommand(c.Target, c.Sender, strings.Join(cmd, " "))
+	cm := NewCommand(c.Target, c.Sender, strings.Join(cmd, " "), c.Nick)
 	cm.Parent = c
 	return cm
 }
@@ -32,12 +30,11 @@ func (c *Command) SplitLine(target string, sender string, cli string) {
 	line := strings.Split(cli, " ")
 	c.Target = target
 	c.Sender = sender
-	nick := viper.GetString("nick")
 	switch target[0] {
 	case '#':
 		switch line[0][0] {
 		case '&', '+', '!':
-			if strings.HasPrefix(line[0], "!"+nick) {
+			if strings.HasPrefix(line[0], "!"+c.Nick) {
 				c.Cmd = line[1]
 				c.Args = line[2:]
 			} else {
@@ -51,8 +48,8 @@ func (c *Command) SplitLine(target string, sender string, cli string) {
 	}
 }
 
-func NewCommand(target string, sender string, cli string) *Command {
-	c := &Command{}
+func NewCommand(target string, sender string, cli string, nick string) *Command {
+	c := &Command{Nick: nick}
 	c.SplitLine(target, sender, cli)
 	return c
 }


### PR DESCRIPTION
There are a few places where the nick was fetched via viper. I think
sourcing from one place will lead to better testability. Also, I fixed
help to use the current nick instead of hardcoded "quartermaster" in
its message.

Signed-off-by: Bradon Kanyid <rattboi@gmail.com>